### PR TITLE
server: Fix build when printf is a macro

### DIFF
--- a/server/main.c
+++ b/server/main.c
@@ -112,9 +112,10 @@ static void
 usage (void)
 {
   /* --{short,long}-options remain undocumented */
-  printf (
+  char const *opt_list =
 #include "synopsis.c"
-  );
+	  ;
+  printf ("%s\n", opt_list);
   printf ("\n"
           "Please read the nbdkit(1) manual page for full usage.\n");
 }


### PR DESCRIPTION
clang complains on x86 when building

main.c:116:2: error: embedding a #include directive within macro arguments is not supported
 ^

convert nesting include into a string assignment, to same effect but
making it compatible with clang as well

Signed-off-by: Khem Raj <raj.khem@gmail.com>