### PR TITLE
configure.ac: Fix cleanup attribute test with clang

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -261,6 +261,7 @@ void
 test (void)
 {
   __attribute__((cleanup(freep))) char *ptr = malloc (100);
+  (void)ptr;
 }
 
 int


### PR DESCRIPTION
In contast to GCC, clang does not consider a variable with the cleanup
attribute 'used', i.e. code like

   __attribute__((cleanup(freep))) char *ptr = malloc (100);

causes a warning about an unused variable. Fix this by using the
varible once in the configure check.