### PR TITLE
Rust plugin: fix warnings during doc generation

### DIFF
--- a/plugins/rust/src/lib.rs
+++ b/plugins/rust/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! NBDKit is a toolkit for building Network Block Device servers.
 //!
-//! [https://github.com/libguestfs/nbdkit](https://github.com/libguestfs/nbdkit)
+//! <https://github.com/libguestfs/nbdkit>
 //!
 //! To use nbdkit, build your project as a cdylib.  Define your plugin by
 //! implementing [`Server`], and then register it with [`plugin!`].  See 
@@ -812,9 +812,11 @@ pub trait Server {
     /// For security reasons (to avoid denial of service attacks) this callback
     /// should be written to be as fast and take as few resources as possible.
     /// If you use this callback, only use it to do basic access control, such
-    /// as checking [`peername`] against a whitelist.  It may be better to do
-    /// access control outside the server, for example using TCP wrappers or a
-    /// firewall.
+    /// as checking
+    #[cfg_attr(feature = "nix", doc = "[`peername`]")]
+    #[cfg_attr(not(feature = "nix"), doc = "the peer name")]
+    /// against a whitelist.  It may be better to do access control outside the
+    /// server, for example using TCP wrappers or a firewall.
     ///
     /// The `readonly` flag informs the plugin that the server was started with
     /// the `-r` flag on the command line.

--- a/plugins/rust/src/lib.rs
+++ b/plugins/rust/src/lib.rs
@@ -217,9 +217,9 @@ pub enum CacheFlags {
     Native = 2,
 }
 
-impl Into<i32> for CacheFlags {
-    fn into(self) -> i32 {
-        self as i32
+impl From<CacheFlags> for i32 {
+    fn from(cf: CacheFlags) -> Self {
+        cf as Self
     }
 }
 
@@ -238,9 +238,9 @@ pub enum FuaFlags {
     Native = 2,
 }
 
-impl Into<i32> for FuaFlags {
-    fn into(self) -> i32 {
-        self as i32
+impl From<FuaFlags> for i32 {
+    fn from(cf: FuaFlags) -> Self {
+        cf as Self
     }
 }
 


### PR DESCRIPTION
A more recent Rust compiler has gotten pickier about links.